### PR TITLE
Examples and Refactoring for ScatterPlotGenerator#to_js

### DIFF
--- a/lib/turbulence/scatter_plot_generator.rb
+++ b/lib/turbulence/scatter_plot_generator.rb
@@ -42,17 +42,19 @@ class Turbulence
 
       directory_series = {}
       grouped_by_directory.each_pair do |directory, metrics_hash|
-        data_in_json_format = metrics_hash.map do |filename, metrics|
-          {:filename => filename, :x => metrics[x_metric], :y => metrics[y_metric]}
-        end.reject(&method(:one_of_the_metrics_is_nil))
+        data_in_json_format = metrics_hash.select do |filename, metrics|
+          unless metrics[x_metric].nil? || metrics[y_metric].nil?
+            {
+              :filename => filename,
+              :x => metrics[x_metric],
+              :y => metrics[y_metric]
+            }
+          end
+        end
         directory_series[directory] = data_in_json_format
       end
 
       "var directorySeries = #{directory_series.to_json};"
-    end
-
-    def one_of_the_metrics_is_nil(metrics)
-      metrics[:x].nil? || metrics[:y].nil?
     end
   end
 end

--- a/spec/turbulence/scatter_splot_generator_spec.rb
+++ b/spec/turbulence/scatter_splot_generator_spec.rb
@@ -1,6 +1,29 @@
 require 'turbulence'
 
 describe Turbulence::ScatterPlotGenerator do
+  context "with both Metrics" do
+    it "generates JavaScript" do
+      generator = Turbulence::ScatterPlotGenerator.new(
+        "foo.rb" => {
+          Turbulence::Calculators::Churn => 1,
+          Turbulence::Calculators::Complexity => 2
+        }
+      )
+      generator.to_js.should == 'var directorySeries = {".":[["foo.rb",{"Turbulence::Calculators::Churn":1,"Turbulence::Calculators::Complexity":2}]]};'
+    end  
+  end
+
+  context "with a missing Metric" do
+    it "generates JavaScript" do
+      generator = Turbulence::ScatterPlotGenerator.new(
+        "foo.rb" => {
+          Turbulence::Calculators::Churn => 1
+        }
+      )
+      generator.to_js.should == 'var directorySeries = {".":[]};'
+    end  
+  end
+  
   describe Turbulence::FileNameMangler do
     subject { Turbulence::FileNameMangler.new }
     it "anonymizes a string" do
@@ -13,7 +36,7 @@ describe Turbulence::ScatterPlotGenerator do
 
     it "honors leading path separators" do
       subject.mangle_name("/a/b/c.rb").should == "/1/2/3.rb"
-    end
+    end    
   end
 end
 


### PR DESCRIPTION
I ran bule on Turbulence and figured I'd attack the nastiest method. Then saw it didn't have coverage. So I wrote a couple examples, and did a little refactoring to reduce the flog score by about 10.
