### PR TITLE
Command line options

### DIFF
--- a/lib/turbulence/command_line_interface.rb
+++ b/lib/turbulence/command_line_interface.rb
@@ -1,5 +1,6 @@
 require 'fileutils'
 require 'launchy'
+require 'optparse'
 
 class Turbulence
   class CommandLineInterface
@@ -10,6 +11,22 @@ class Turbulence
 
     attr_reader :directory
     def initialize(argv)
+      OptionParser.new do |opts|
+        opts.banner = "Usage: bule [options] [dir]"
+        
+        opts.on('--churn-range since..until', String, 'commit range to compute file churn') do |s|
+          Turbulence::Calculators::Churn.commit_range = s
+        end
+        opts.on('--churn-mean', 'calculate mean churn instead of cummulative') do
+          Turbulence::Calculators::Churn.compute_mean = true
+        end
+        
+        opts.on_tail("-h", "--help", "Show this message") do
+          puts opts
+          exit
+        end
+      end.parse!(argv)
+      
       @directory = argv.first || Dir.pwd
     end
 

--- a/spec/turbulence/calculators/churn_spec.rb
+++ b/spec/turbulence/calculators/churn_spec.rb
@@ -66,6 +66,33 @@ describe Turbulence::Calculators::Churn do
       calculator.counted_line_changes_by_file_by_commit.should =~ [["lib/turbulence.rb", 16], ["lib/eddies.rb", 19]]
     end
   end
+  
+  describe "::changes_by_ruby_file" do
+    before do
+      calculator.stub(:ruby_files_changed_in_git) {
+        [
+          ['lib/eddies.rb', 4],
+          ['lib/turbulence.rb', 5],
+          ['lib/turbulence.rb', 16],
+          ['lib/eddies.rb', 2],
+          ['lib/turbulence.rb', 7],
+          ['lib/eddies.rb', 19],
+          ['lib/eddies.rb', 28]
+        ]
+      }
+    end
+    
+    it "groups and sums churns, excluding the last" do
+      calculator.compute_mean = false
+      calculator.changes_by_ruby_file.should =~ [ ['lib/eddies.rb', 25], ['lib/turbulence.rb', 21]]
+    end
+    
+    it "groups and takes the mean of churns, excluding the last" do
+      calculator.compute_mean = true
+      calculator.changes_by_ruby_file.should =~ [ ['lib/eddies.rb', 8], ['lib/turbulence.rb', 10]]
+      calculator.compute_mean = false
+    end
+  end
 
   context "Full stack tests" do
     context "when one ruby file is given" do

--- a/spec/turbulence/command_line_interface_spec.rb
+++ b/spec/turbulence/command_line_interface_spec.rb
@@ -14,4 +14,18 @@ describe Turbulence::CommandLineInterface do
       Dir.glob('turbulence/*').should eq(["turbulence/cc.js", "turbulence/highcharts.js", "turbulence/jquery.min.js", "turbulence/turbulence.html"])
     end
   end
+  describe "command line options" do
+    let(:cli_churn_range) { Turbulence::CommandLineInterface.new(%w(--churn-range f3e1d7a6..830b9d3d9f path/to/compute)) }
+    let(:cli_churn_mean) { Turbulence::CommandLineInterface.new(%w(--churn-mean .)) }
+
+    it "sets churn range" do
+      cli_churn_range.directory.should == 'path/to/compute'
+      Turbulence::Calculators::Churn.commit_range.should == 'f3e1d7a6..830b9d3d9f'
+    end
+    
+    it "sets churn mean" do
+      cli_churn_mean.directory.should == '.'
+      Turbulence::Calculators::Churn.compute_mean.should be_true
+    end
+  end
 end


### PR DESCRIPTION
This was a quick first stab at a couple command line options that were of interest to me.  I've got mixed feelings on using meta-class attributes for this, but it was more straight-forward than passing around option hashes to each singleton method in Turbulence::Calculators::Churn.  If nothing else, there's now a spec for Churn::changes_by_ruby_file.
