### PR TITLE
--exclude option to exclude files by pattern.

### DIFF
--- a/lib/turbulence.rb
+++ b/lib/turbulence.rb
@@ -8,10 +8,12 @@ class Turbulence
   CODE_DIRECTORIES = ["app/models", "app/controllers", "app/helpers", "lib"]
   CALCULATORS = [Turbulence::Calculators::Complexity, Turbulence::Calculators::Churn]
 
+  attr_reader :exclusion_pattern
   attr_reader :metrics
-  def initialize(directory, output = nil)
+  def initialize(directory, output = nil, exclusion_pattern = nil)
     @output = output
     @metrics = {}
+    @exclusion_pattern = exclusion_pattern
     Dir.chdir(directory) do
       CALCULATORS.each(&method(:calculate_metrics_with))
     end
@@ -19,7 +21,7 @@ class Turbulence
 
   def files_of_interest
     file_list = CODE_DIRECTORIES.map{|base_dir| "#{base_dir}/**/*\.rb"}
-    @ruby_files ||= Dir[*file_list]
+    @ruby_files ||= exclude_files(Dir[*file_list])
   end
 
   def calculate_metrics_with(calculator)
@@ -43,4 +45,11 @@ class Turbulence
     @metrics[filename] ||= {}
   end
 
+  private
+  def exclude_files(files)
+    if not @exclusion_pattern.nil?
+      files = files.reject { |f| f =~ Regexp.new(@exclusion_pattern) }
+    end
+    files
+  end
 end

--- a/spec/turbulence/command_line_interface_spec.rb
+++ b/spec/turbulence/command_line_interface_spec.rb
@@ -16,10 +16,18 @@ describe Turbulence::CommandLineInterface do
       cli.generate_bundle
       Dir.glob('turbulence/*').should eq(["turbulence/cc.js", "turbulence/highcharts.js", "turbulence/jquery.min.js", "turbulence/turbulence.html"])
     end
+
+    it "passes along exclusion pattern" do
+      cli = Turbulence::CommandLineInterface.new(%w(--exclude turbulence))
+      cli.generate_bundle
+      lines = File.new('turbulence/cc.js').readlines
+      lines.any? { |l| l =~ /turbulence\.rb/ }.should be_false
+    end
   end
   describe "command line options" do
     let(:cli_churn_range) { Turbulence::CommandLineInterface.new(%w(--churn-range f3e1d7a6..830b9d3d9f path/to/compute)) }
     let(:cli_churn_mean) { Turbulence::CommandLineInterface.new(%w(--churn-mean .)) }
+    let(:cli_exclusion_pattern) { Turbulence::CommandLineInterface.new(%w(--exclude turbulence)) }
 
     it "sets churn range" do
       cli_churn_range.directory.should == 'path/to/compute'
@@ -29,6 +37,10 @@ describe Turbulence::CommandLineInterface do
     it "sets churn mean" do
       cli_churn_mean.directory.should == '.'
       Turbulence::Calculators::Churn.compute_mean.should be_true
+    end
+
+    it "sets the exclusion pattern" do
+      cli_exclusion_pattern.exclusion_pattern.should == 'turbulence'
     end
   end
 end

--- a/spec/turbulence/turbulence_spec.rb
+++ b/spec/turbulence/turbulence_spec.rb
@@ -1,0 +1,15 @@
+require 'rspec'
+require 'turbulence'
+
+describe Turbulence do
+  it "finds files of interest" do
+    turb = Turbulence.new(".")
+    turb.exclusion_pattern.should be_nil
+    turb.files_of_interest.should include "lib/turbulence.rb"
+  end
+  
+  it "filters out exluded files" do
+    turb = Turbulence.new(".", nil, 'turbulence')
+    turb.files_of_interest.should_not include "lib/turbulence.rb"
+  end
+end


### PR DESCRIPTION
(a feature prompted by a chat with Michael Feathers...)

Thought it might be useful to sometimes exclude some files from processing.  That way if you have one or a set of files which have extreme turbulence you can exclude them to get more info on the non-extreme items.
