### PR TITLE
Fix file opening on windows

### DIFF
--- a/lib/turbulence/command_line_interface.rb
+++ b/lib/turbulence/command_line_interface.rb
@@ -18,6 +18,7 @@ class Turbulence
     attr_reader :directory
     def initialize(argv)
       Turbulence::Calculators::Churn.scm = Scm::Git
+      @graph_type = "turbulence"
       OptionParser.new do |opts|
         opts.banner = "Usage: bule [options] [dir]"
 
@@ -77,12 +78,7 @@ class Turbulence
     end
 
     def open_bundle
-      case @graph_type
-      when "treemap"
-        Launchy.open("file:///#{directory}/turbulence/treemap.html")
-      else
-        Launchy.open("file:///#{directory}/turbulence/turbulence.html")
-      end
+      Launchy.open("file:///#{directory}/turbulence/#{@graph_type}.html")
     end
   end
 end


### PR DESCRIPTION
Fixes #19.

I used the `letter_opener` gem [as a reference](https://github.com/ryanb/letter_opener/commit/3a2e31eefc6515fe95ab0f1bc4fcfc9468d7c514) for fixing this. Turbulence now works on my Windows machine :)

If you want, you can just cherry pick the first commit or I can remove that second commit. I'm not sure if it was really warranted.
