### PR TITLE
Actually shut up STDOUT during testing

### DIFF
--- a/lib/turbulence/command_line_interface.rb
+++ b/lib/turbulence/command_line_interface.rb
@@ -16,7 +16,7 @@ class Turbulence
 
     attr_reader :exclusion_pattern
     attr_reader :directory
-    def initialize(argv)
+    def initialize(argv, additional_options = {})
       Turbulence::Calculators::Churn.scm = Scm::Git
       @graph_type = "turbulence"
       OptionParser.new do |opts|
@@ -54,6 +54,7 @@ class Turbulence
       end.parse!(argv)
 
       @directory = argv.first || Dir.pwd
+      @output = additional_options.fetch(:output, STDOUT)
     end
 
     def copy_templates_into(directory)
@@ -64,7 +65,7 @@ class Turbulence
       FileUtils.mkdir_p("turbulence")
 
       Dir.chdir("turbulence") do
-        turb = Turbulence.new(directory,STDOUT, @exclusion_pattern)
+        turb = Turbulence.new(directory, @output, @exclusion_pattern)
 
         generator = case @graph_type
         when "treemap"

--- a/spec/turbulence/command_line_interface_spec.rb
+++ b/spec/turbulence/command_line_interface_spec.rb
@@ -2,7 +2,7 @@ require 'rspec'
 require 'turbulence'
 
 describe Turbulence::CommandLineInterface do
-  let(:cli) { Turbulence::CommandLineInterface.new(%w(.)) }
+  let(:cli) { Turbulence::CommandLineInterface.new(%w(.), :output => nil) }
   describe "::TEMPLATE_FILES" do
     Turbulence::CommandLineInterface::TEMPLATE_FILES.each do |template_file|
       File.dirname(template_file).should == Turbulence::CommandLineInterface::TURBULENCE_TEMPLATE_PATH
@@ -22,7 +22,7 @@ describe Turbulence::CommandLineInterface do
     end
 
     it "passes along exclusion pattern" do
-      cli = Turbulence::CommandLineInterface.new(%w(--exclude turbulence))
+      cli = Turbulence::CommandLineInterface.new(%w(--exclude turbulence), :output => nil)
       cli.generate_bundle
       lines = File.new('turbulence/cc.js').readlines
       lines.any? { |l| l =~ /turbulence\.rb/ }.should be_false


### PR DESCRIPTION
In the spirit of issue #3, this removes the "calculating metric: <calculator name>" output when running rake.

However, I'm still getting a message "sh: git: No such file or directory", and I'm having a hard time figuring out where it's coming from, because the specs appear to have side effects.  The output appears to be coming from spec/turbulence/turbulence_spec.rb; however, the code explodes when I run that spec file by itself.
