### PR TITLE
Use class names rather than objects as metrics_hash keys

### DIFF
--- a/lib/turbulence.rb
+++ b/lib/turbulence.rb
@@ -55,7 +55,7 @@ class Turbulence
 
     calculator.for_these_files(files_of_interest) do |filename, score|
       report "."
-      set_file_metric(filename, calculator, score)
+      set_file_metric(filename, calculator.class, score)
     end
 
     report "\n"


### PR DESCRIPTION
In the change to move configuration into its own object, this slipped past us. The metrics hash uses the Class name as the key (and the results of that calculator as the values, naturally.) However, since the metric generators are now instances as opposed to class methods, we are setting the object as the hash key rather than its class. This change is to use the class name rather than the class name + object ID as the keys for the eventual metrics hash. This bug resulted in no metrics being displayed in the output reports. :bug:
