### PR TITLE
Remove use of class names as metrics_hash keys

### DIFF
--- a/lib/turbulence.rb
+++ b/lib/turbulence.rb
@@ -55,7 +55,7 @@ class Turbulence
 
     calculator.for_these_files(files_of_interest) do |filename, score|
       report "."
-      set_file_metric(filename, calculator.class, score)
+      set_file_metric(filename, calculator.type, score)
     end
 
     report "\n"

--- a/lib/turbulence/calculators/churn.rb
+++ b/lib/turbulence/calculators/churn.rb
@@ -5,9 +5,11 @@ class Turbulence
     class Churn
       RUBY_FILE_EXTENSION = ".rb"
 
-      attr_reader :config
+      attr_reader :config, :type
+
       def initialize(config = nil)
         @config = config || Turbulence.config
+        @type = :churn
       end
 
       extend Forwardable

--- a/lib/turbulence/calculators/complexity.rb
+++ b/lib/turbulence/calculators/complexity.rb
@@ -18,9 +18,11 @@ end
 class Turbulence
   module Calculators
     class Complexity
-      attr_reader :config
+      attr_reader :config, :type
+
       def initialize(config = nil)
         @config = config || Turbulence.config
+        @type = :complexity
       end
 
       def flogger

--- a/lib/turbulence/generators/scatterplot.rb
+++ b/lib/turbulence/generators/scatterplot.rb
@@ -4,8 +4,8 @@ class Turbulence
       attr_reader :metrics_hash, :x_metric, :y_metric
 
       def initialize(metrics_hash,
-                     x_metric = Turbulence::Calculators::Churn,
-                     y_metric = Turbulence::Calculators::Complexity)
+                     x_metric = :churn,
+                     y_metric = :complexity)
         @x_metric     = x_metric
         @y_metric     = y_metric
         @metrics_hash = metrics_hash

--- a/lib/turbulence/generators/treemap.rb
+++ b/lib/turbulence/generators/treemap.rb
@@ -4,8 +4,8 @@ class Turbulence
       attr_reader :metrics_hash, :x_metric, :y_metric
 
       def initialize(metrics_hash,
-                     x_metric = Turbulence::Calculators::Churn,
-                     y_metric = Turbulence::Calculators::Complexity)
+                     x_metric = :churn,
+                     y_metric = :complexity)
         @x_metric     = x_metric
         @y_metric     = y_metric
         @metrics_hash = metrics_hash

--- a/spec/turbulence/generators/scatter_plot_spec.rb
+++ b/spec/turbulence/generators/scatter_plot_spec.rb
@@ -4,8 +4,8 @@ describe Turbulence::Generators::ScatterPlot do
   context "with both Metrics" do
     it "generates JavaScript" do
       generator = Turbulence::Generators::ScatterPlot.new(
-        "foo.rb" => { Turbulence::Calculators::Churn      => 1,
-                      Turbulence::Calculators::Complexity => 2 }
+        "foo.rb" => { :churn      => 1,
+                      :complexity => 2 }
       )
 
       generator.to_js.should =~ /var directorySeries/
@@ -18,7 +18,7 @@ describe Turbulence::Generators::ScatterPlot do
   context "with a missing Metric" do
     it "generates JavaScript" do
       generator = Turbulence::Generators::ScatterPlot.new(
-        "foo.rb" => { Turbulence::Calculators::Churn => 1 }
+        "foo.rb" => { :churn => 1 }
       )
 
       generator.to_js.should == 'var directorySeries = {};'
@@ -30,40 +30,42 @@ describe Turbulence::Generators::ScatterPlot do
 
     it "removes entries with missing churn" do
       spg.stub(:metrics_hash).and_return("foo.rb" => {
-        Turbulence::Calculators::Complexity => 88.3})
+        :complexity => 88.3})
         spg.clean_metrics_from_missing_data.should == {}
     end
 
     it "removes entries with missing complexity" do
       spg.stub(:metrics_hash).and_return("foo.rb" => {
-        Turbulence::Calculators::Churn => 1})
+        :churn => 1})
         spg.clean_metrics_from_missing_data.should == {}
     end
 
     it "keeps entries with churn and complexity present" do
       spg.stub(:metrics_hash).and_return("foo.rb" => {
-        Turbulence::Calculators::Churn => 1,
-        Turbulence::Calculators::Complexity => 88.3})
+        :churn      => 1,
+        :complexity => 88.3,
+        })
+
         spg.clean_metrics_from_missing_data.should_not == {}
     end
   end
 
   describe "#grouped_by_directory" do
     let(:spg) {Turbulence::Generators::ScatterPlot.new("lib/foo/foo.rb" => {
-      Turbulence::Calculators::Churn => 1},
+      :churn => 1},
       "lib/bar.rb" => {
-      Turbulence::Calculators::Churn => 2} )}
+      :churn => 2} )}
 
       it "uses \".\" to denote flat hierarchy" do
         spg.stub(:metrics_hash).and_return("foo.rb" => {
-          Turbulence::Calculators::Churn => 1
+          :churn => 1
         })
-        spg.grouped_by_directory.should == {"." => [["foo.rb", {Turbulence::Calculators::Churn => 1}]]}
+        spg.grouped_by_directory.should == {"." => [["foo.rb", {:churn => 1}]]}
       end
 
       it "takes full path into account" do
-        spg.grouped_by_directory.should == {"lib/foo" => [["lib/foo/foo.rb", {Turbulence::Calculators::Churn => 1}]],
-          "lib" => [["lib/bar.rb", {Turbulence::Calculators::Churn => 2}]]}
+        spg.grouped_by_directory.should == {"lib/foo" => [["lib/foo/foo.rb", {:churn => 1}]],
+          "lib" => [["lib/bar.rb", {:churn => 2}]]}
       end
   end
 
@@ -71,9 +73,9 @@ describe Turbulence::Generators::ScatterPlot do
     let(:spg) {Turbulence::Generators::ScatterPlot.new({})}
     it "assigns :filename, :x, :y" do
       spg.file_metrics_for_directory("lib/foo/foo.rb" => {
-        Turbulence::Calculators::Churn => 1,
-        Turbulence::Calculators::Complexity => 88.2}).should == [{:filename => "lib/foo/foo.rb",
-        :x => 1, :y => 88.2}]
+        :churn      => 1,
+        :complexity => 88.2,
+      }).should == [{:filename => "lib/foo/foo.rb", :x => 1, :y => 88.2}]
     end
   end
 

--- a/spec/turbulence/generators/treemap_spec.rb
+++ b/spec/turbulence/generators/treemap_spec.rb
@@ -4,8 +4,8 @@ describe Turbulence::Generators::TreeMap do
   context "with both Metrics" do
     it "generates JavaScript" do
       generator = Turbulence::Generators::TreeMap.new(
-        "foo.rb" => { Turbulence::Calculators::Churn      => 1,
-                      Turbulence::Calculators::Complexity => 2 }
+        "foo.rb" => { :churn      => 1,
+                      :complexity => 2 }
       )
 
       generator.build_js.should =~ /var treemap_data/
@@ -16,7 +16,7 @@ describe Turbulence::Generators::TreeMap do
   context "with a missing Metric" do
     it "generates JavaScript" do
       generator = Turbulence::Generators::TreeMap.new(
-        "foo.rb" => { Turbulence::Calculators::Churn => 1 }
+        "foo.rb" => { :churn => 1 }
       )
 
       generator.build_js.should == "var treemap_data = [['File', 'Parent', 'Churn (size)', 'Complexity (color)'],\n['Root', null, 0, 0],\n];"


### PR DESCRIPTION
As a follow on to the previous PR fixing the bug caused by using class names as hash keys, I took a stab at removing the use of class names as the metrics_hash's keys, replacing them with a `type` attribute on the generator. I had originally decided to spend my weekend addressing #20 before fixing bugs, and decided that it might be best to have both the original churn calculator as well as a new one based on the Churn gem, as the Churn gem doesn't support perforce (and I don't know enough about it to work on a PR - sorry, @danmayer!)

One interesting wrinkle to this change is that it would allow for the addition of Calculators of many different metric types. Mashing up metrics might be a useful 2.0 feature..

I'm not 100% on this change, and am actively seeking feedback. 
