### PR TITLE
Update referenced URL, description content in the gemspec description

### DIFF
--- a/turbulence.gemspec
+++ b/turbulence.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rake'
 
   s.summary     = %q{Automates churn + flog scoring on a git repo for a Ruby project}
-  s.description = %q{Based on this http://www.stickyminds.com/sitewide.asp?Function=edetail&ObjectType=COL&ObjectId=16679&tth=DYN&tt=siteemail&iDyn=2}
+  s.description = %q{Automates churn + flog scoring on a git repo for a Ruby project. Based on the article https://www.stickyminds.com/article/getting-empirical-about-refactoring}
 
   s.rubyforge_project = "turbulence"
 


### PR DESCRIPTION
The existing linked URL had a bunch of email newsletter stuff in it, so I went and got the 'true' URL of the article instead. In the future, when the article breaks, it may also help in googling for its new location.

Also added the summary into the description, since the description is the only thing that seems to appear on the rubygems web UI. The summary looks like it may be only for gem list -d.