### PR TITLE
Update rspec and require newer Ruby versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,37 +3,70 @@ PATH
   specs:
     turbulence (1.2.4)
       flog (~> 4.1)
-      json (>= 1.4.6)
+      json (>= 2.7.2)
       launchy (>= 2.0.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.3.6)
-    diff-lcs (1.2.5)
-    flog (4.2.1)
+    addressable (2.8.7)
+      public_suffix (>= 2.0.2, < 7.0)
+    childprocess (5.1.0)
+      logger (~> 1.5)
+    debug (1.9.2)
+      irb (~> 1.10)
+      reline (>= 0.3.8)
+    diff-lcs (1.5.1)
+    flog (4.8.0)
+      path_expander (~> 1.0)
       ruby_parser (~> 3.1, > 3.1.0)
-      sexp_processor (~> 4.4)
-    json (1.8.1)
-    launchy (2.4.2)
-      addressable (~> 2.3)
-    rake (10.1.0)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.7)
-    rspec-expectations (2.14.4)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.4)
-    ruby_parser (3.6.1)
-      sexp_processor (~> 4.1)
-    sexp_processor (4.4.3)
+      sexp_processor (~> 4.8)
+    io-console (0.7.2)
+    irb (1.14.1)
+      rdoc (>= 4.0.0)
+      reline (>= 0.4.2)
+    json (2.7.2)
+    launchy (3.0.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+    logger (1.6.1)
+    path_expander (1.1.3)
+    psych (5.1.2)
+      stringio
+    public_suffix (6.0.1)
+    racc (1.8.1)
+    rake (13.2.1)
+    rdoc (6.7.0)
+      psych (>= 4.0.0)
+    reline (0.5.10)
+      io-console (~> 0.5)
+    rspec (3.13.0)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.1)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.3)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-mocks (3.13.2)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.1)
+    ruby_parser (3.21.1)
+      racc (~> 1.5)
+      sexp_processor (~> 4.16)
+    sexp_processor (4.17.2)
+    stringio (3.1.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
+  debug
   rake
-  rspec (~> 2.14.0)
+  rspec (~> 3.13.0)
   turbulence!
+
+BUNDLED WITH
+   2.5.17

--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ require 'rake'
 require 'rspec/core/rake_task'
 
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.skip_bundler = true
+  # t.skip_bundler = true
 end
 
 task :default => [:spec]

--- a/lib/turbulence/calculators/complexity.rb
+++ b/lib/turbulence/calculators/complexity.rb
@@ -1,20 +1,6 @@
 require 'stringio'
 require 'flog'
 
-class Ruby19Parser < RubyParser
-  def process(ruby, file)
-    ruby.gsub!(/(\w+):\s+/, '"\1" =>')
-    super(ruby, file)
-  end
-end unless defined?(:Ruby19Parser)
-
-class Flog19 < Flog
-  def initialize option = {}
-    super(option)
-    @parser = Ruby19Parser.new
-  end
-end
-
 class Turbulence
   module Calculators
     class Complexity
@@ -26,7 +12,7 @@ class Turbulence
       end
 
       def flogger
-        @flogger ||= Flog19.new(:continue => true)
+        @flogger ||= Flog.new(:continue => true)
       end
 
       def for_these_files(files)

--- a/lib/turbulence/cli_parser.rb
+++ b/lib/turbulence/cli_parser.rb
@@ -4,42 +4,47 @@ class Turbulence
     # expectations (as expressed in ARGV)
     module ConfigParser
       def self.parse_argv_into_config(argv, config)
-        option_parser = OptionParser.new do |opts|
+        OptionParser.new do |opts|
           opts.banner = "Usage: bule [options] [dir]"
 
-          opts.on('--scm p4|git', String, 'scm to use (default: git)') do |s|
-            case s
-            when "git", "", nil
-            when "p4"
-              config.scm_name = 'Perforce'
-            end
+          # Use `accept` for type validation and conversion
+          opts.accept(Symbol) do |s|
+            s.to_sym if %w[git p4].include?(s)
           end
 
-          opts.on('--churn-range since..until', String, 'commit range to compute file churn') do |s|
+          opts.on('--scm=SCM', Symbol, 'SCM to use: git or p4 (default: git)') do |s|
+            config.scm_name = s == :p4 ? 'Perforce' : 'Git'
+          end
+
+          opts.on('--churn-range=RANGE', String, 'Commit range to compute file churn') do |s|
             config.commit_range = s
           end
 
-          opts.on('--churn-mean', 'calculate mean churn instead of cummulative') do
+          opts.on('--churn-mean', 'Calculate mean churn instead of cumulative') do
             config.compute_mean = true
           end
 
-          opts.on('--exclude pattern', String, 'exclude files matching pattern') do |pattern|
+          opts.on('--exclude=PATTERN', String, 'Exclude files matching pattern') do |pattern|
             config.exclusion_pattern = pattern
           end
 
-          opts.on('--treemap', String, 'output treemap graph instead of scatterplot') do |s|
+          opts.on('--treemap', 'Output treemap graph instead of scatterplot') do
             config.graph_type = "treemap"
           end
 
+          opts.on('--[no-]open', 'Open the generated bundle (default: open)') do |v|
+            config.open_bundle = v
+          end
 
-          opts.on_tail("-h", "--help", "Show this message") do
+          opts.on_tail('-h', '--help', 'Show this message') do
             puts opts
             exit
           end
-        end
-        option_parser.parse!(argv)
 
-        config.directory = argv.first unless argv.empty?
+        end.parse!(argv)
+
+        # Set directory if provided
+        config.directory = argv.first if argv.any?
       end
     end
   end

--- a/lib/turbulence/command_line_interface.rb
+++ b/lib/turbulence/command_line_interface.rb
@@ -55,6 +55,7 @@ class Turbulence
     end
 
     def open_bundle
+      return unless config.open_bundle
       Launchy.open("file:///#{directory}/turbulence/#{graph_type}.html")
     end
   end

--- a/lib/turbulence/configuration.rb
+++ b/lib/turbulence/configuration.rb
@@ -11,13 +11,15 @@ class Turbulence
       :exclusion_pattern,
       :graph_type,
       :output,
+      :open_bundle,
     ]
 
     def initialize
-      @directory  = Dir.pwd
-      @graph_type = 'turbulence'
-      @scm_name   = 'Git'
-      @output     = STDOUT
+      @directory   = Dir.pwd
+      @graph_type  = 'turbulence'
+      @scm_name    = 'Git'
+      @output      = STDOUT
+      @open_bundle = true
     end
 
     # TODO: drop attr accessor and ivar once it stops getting set via Churn

--- a/lib/turbulence/scm/git.rb
+++ b/lib/turbulence/scm/git.rb
@@ -8,7 +8,7 @@ class Turbulence
 
         def is_repo?(directory)
           FileUtils.cd(directory) {
-            return !(`git status 2>&1` =~ /Not a git repository/)
+            return !(`git status 2>&1` =~ /Not a git repository/i)
           }
         end
       end

--- a/spec/turbulence/cli_parser_spec.rb
+++ b/spec/turbulence/cli_parser_spec.rb
@@ -25,7 +25,7 @@ describe Turbulence::CommandLineInterface::ConfigParser do
 
   it "sets compute mean" do
     parse %w( --churn-mean )
-    config.compute_mean.should be_true
+    config.compute_mean.should be true
   end
 
   it "sets the exclusion pattern" do

--- a/spec/turbulence/command_line_interface_spec.rb
+++ b/spec/turbulence/command_line_interface_spec.rb
@@ -27,7 +27,7 @@ describe Turbulence::CommandLineInterface do
       cli = Turbulence::CommandLineInterface.new(%w(--exclude turbulence), :output => nil)
       cli.generate_bundle
       lines = File.new('turbulence/cc.js').readlines
-      lines.any? { |l| l =~ /turbulence\.rb/ }.should be_false
+      lines.any? { |l| l =~ /turbulence\.rb/ }.should be false
     end
   end
 end

--- a/spec/turbulence/configuration_spec.rb
+++ b/spec/turbulence/configuration_spec.rb
@@ -3,11 +3,11 @@ require 'turbulence'
 
 describe Turbulence::Configuration do
   describe "defaults" do
-    its(:output)     { should eq(STDOUT) }
-    its(:directory)  { should eq(Dir.pwd) }
-    its(:graph_type) { should eq('turbulence') }
-    its(:scm_name)   { should eq('Git') }
-    its(:scm)        { should eq(Turbulence::Scm::Git) }
+    it { expect(subject.output).to eq(STDOUT) }
+    it { expect(subject.directory).to eq(Dir.pwd) }
+    it { expect(subject.graph_type).to eq('turbulence') }
+    it { expect(subject.scm_name).to eq('Git') }
+    it { expect(subject.scm).to eq(Turbulence::Scm::Git) }
   end
 end
 

--- a/spec/turbulence/scm/perforce_spec.rb
+++ b/spec/turbulence/scm/perforce_spec.rb
@@ -50,15 +50,15 @@ changed 1 chunks 3 / 1 lines"
     it "returns true if P4CLIENT is set " do
       ENV.stub(:[]).with("P4CLIENT").and_return("c-foo.bar")
 
-      Turbulence::Scm::Perforce.is_repo?(".").should be_true
+      Turbulence::Scm::Perforce.is_repo?(".").should be true
     end
 
     it "returns false if P4CLIENT is empty"  do
-      Turbulence::Scm::Perforce.is_repo?(".").should be_false
+      Turbulence::Scm::Perforce.is_repo?(".").should be false
     end
 
     it "returns false if p4 is not available" do
-      Turbulence::Scm::Perforce.is_repo?(".").should be_false
+      Turbulence::Scm::Perforce.is_repo?(".").should be false
     end
   end
 

--- a/turbulence.gemspec
+++ b/turbulence.gemspec
@@ -10,10 +10,10 @@ Gem::Specification.new do |s|
   s.email       = ["chad@chadfowler.com", "mfeathers@obtiva.com", "coreyhaines@gmail.com"]
   s.homepage    = "http://chadfowler.com"
   s.add_dependency "flog", "~>4.1"
-  s.add_dependency "json", ">= 1.4.6"
+  s.add_dependency "json", ">= 2.7.2"
   s.add_dependency "launchy", ">= 2.0.0"
-  s.add_development_dependency 'rspec', '~> 2.14.0'
-  s.add_development_dependency 'rake'
+  s.add_development_dependency "rspec", "~> 3.13.0"
+  s.add_development_dependency "rake"
 
   s.summary     = %q{Automates churn + flog scoring on a git repo for a Ruby project}
   s.description = %q{Automates churn + flog scoring on a git repo for a Ruby project. Based on the article https://www.stickyminds.com/article/getting-empirical-about-refactoring}
@@ -22,5 +22,5 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = ">= 3.2.0"
 end


### PR DESCRIPTION
This removes support for ruby 1.9 and removes the patches for the parser and Flog.