### PR TITLE
Add Ruby 3.0+ and Ruby 4.0 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,38 +2,84 @@ PATH
   remote: .
   specs:
     turbulence (1.2.4)
-      flog (~> 4.1)
-      json (>= 1.4.6)
+      flog (>= 4.1)
+      json
       launchy (>= 2.0.0)
+      racc
 
 GEM
   remote: http://rubygems.org/
   specs:
-    addressable (2.3.6)
-    diff-lcs (1.2.5)
-    flog (4.2.1)
-      ruby_parser (~> 3.1, > 3.1.0)
-      sexp_processor (~> 4.4)
-    json (1.8.1)
-    launchy (2.4.2)
-      addressable (~> 2.3)
-    rake (10.1.0)
-    rspec (2.14.1)
-      rspec-core (~> 2.14.0)
-      rspec-expectations (~> 2.14.0)
-      rspec-mocks (~> 2.14.0)
-    rspec-core (2.14.7)
-    rspec-expectations (2.14.4)
-      diff-lcs (>= 1.1.3, < 2.0)
-    rspec-mocks (2.14.4)
-    ruby_parser (3.6.1)
-      sexp_processor (~> 4.1)
-    sexp_processor (4.4.3)
+    addressable (2.9.0)
+      public_suffix (>= 2.0.2, < 8.0)
+    childprocess (5.1.0)
+      logger (~> 1.5)
+    diff-lcs (1.6.2)
+    flog (4.9.4)
+      path_expander (~> 2.0)
+      prism (~> 1.7)
+      sexp_processor (~> 4.8)
+    json (2.19.9)
+    launchy (3.1.1)
+      addressable (~> 2.8)
+      childprocess (~> 5.0)
+      logger (~> 1.6)
+    logger (1.7.0)
+    path_expander (2.0.1)
+    prism (1.9.0)
+    public_suffix (7.0.5)
+    racc (1.8.1)
+    rake (13.4.2)
+    rspec (3.13.2)
+      rspec-core (~> 3.13.0)
+      rspec-expectations (~> 3.13.0)
+      rspec-mocks (~> 3.13.0)
+    rspec-core (3.13.6)
+      rspec-support (~> 3.13.0)
+    rspec-expectations (3.13.5)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-its (2.0.0)
+      rspec-core (>= 3.13.0)
+      rspec-expectations (>= 3.13.0)
+    rspec-mocks (3.13.8)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.13.0)
+    rspec-support (3.13.7)
+    sexp_processor (4.17.5)
 
 PLATFORMS
+  arm64-darwin-25
   ruby
 
 DEPENDENCIES
   rake
-  rspec (~> 2.14.0)
+  rspec (~> 3.0)
+  rspec-its
   turbulence!
+
+CHECKSUMS
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
+  bundler (4.0.13) sha256=19f08be7f27022cf0b89f27da0b044ae075e8270a9ef44ad248a932614e1ca3b
+  childprocess (5.1.0) sha256=9a8d484be2fd4096a0e90a0cd3e449a05bc3aa33f8ac9e4d6dcef6ac1455b6ec
+  diff-lcs (1.6.2) sha256=9ae0d2cba7d4df3075fe8cd8602a8604993efc0dfa934cff568969efb1909962
+  flog (4.9.4) sha256=12cc054fab7a2cbd2a906514397c4d7788954d530564782d6f14939dc2dfbcbb
+  json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
+  launchy (3.1.1) sha256=72b847b5cc961589dde2c395af0108c86ff0119f42d4648d25b5440ebb10059e
+  logger (1.7.0) sha256=196edec7cc44b66cfb40f9755ce11b392f21f7967696af15d274dde7edff0203
+  path_expander (2.0.1) sha256=2de201164bff4719cc4d0b3767286e9977cc832a59c4d70abab571ec86cb41e4
+  prism (1.9.0) sha256=7b530c6a9f92c24300014919c9dcbc055bf4cdf51ec30aed099b06cd6674ef85
+  public_suffix (7.0.5) sha256=1a8bb08f1bbea19228d3bed6e5ed908d1cb4f7c2726d18bd9cadf60bc676f623
+  racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
+  rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
+  rspec (3.13.2) sha256=206284a08ad798e61f86d7ca3e376718d52c0bc944626b2349266f239f820587
+  rspec-core (3.13.6) sha256=a8823c6411667b60a8bca135364351dda34cd55e44ff94c4be4633b37d828b2d
+  rspec-expectations (3.13.5) sha256=33a4d3a1d95060aea4c94e9f237030a8f9eae5615e9bd85718fe3a09e4b58836
+  rspec-its (2.0.0) sha256=a88e8bc38149f2835e93533591ec4f5c829aacbfd41269a2e6f9f5b82f5260df
+  rspec-mocks (3.13.8) sha256=086ad3d3d17533f4237643de0b5c42f04b66348c28bf6b9c2d3f4a3b01af1d47
+  rspec-support (3.13.7) sha256=0640e5570872aafefd79867901deeeeb40b0c9875a36b983d85f54fb7381c47c
+  sexp_processor (4.17.5) sha256=ae2b48ba98353d5d465ce8759836b7a05f2e12c5879fcd14d7815b026de32f0e
+  turbulence (1.2.4)
+
+BUNDLED WITH
+  4.0.13

--- a/lib/turbulence/calculators/complexity.rb
+++ b/lib/turbulence/calculators/complexity.rb
@@ -1,20 +1,6 @@
 require 'stringio'
 require 'flog'
 
-class Ruby19Parser < RubyParser
-  def process(ruby, file)
-    ruby.gsub!(/(\w+):\s+/, '"\1" =>')
-    super(ruby, file)
-  end
-end unless defined?(:Ruby19Parser)
-
-class Flog19 < Flog
-  def initialize option = {}
-    super(option)
-    @parser = Ruby19Parser.new
-  end
-end
-
 class Turbulence
   module Calculators
     class Complexity
@@ -26,7 +12,7 @@ class Turbulence
       end
 
       def flogger
-        @flogger ||= Flog19.new(:continue => true)
+        @flogger ||= Flog.new(continue: true)
       end
 
       def for_these_files(files)

--- a/lib/turbulence/configuration.rb
+++ b/lib/turbulence/configuration.rb
@@ -1,5 +1,3 @@
-require 'ostruct'
-
 class Turbulence
   class Configuration
     attr_accessor *[

--- a/lib/turbulence/scm/git.rb
+++ b/lib/turbulence/scm/git.rb
@@ -8,7 +8,7 @@ class Turbulence
 
         def is_repo?(directory)
           FileUtils.cd(directory) {
-            return !(`git status 2>&1` =~ /Not a git repository/)
+            return !(`git status 2>&1` =~ /not a git repository/i)
           }
         end
       end

--- a/spec/turbulence/calculators/churn_spec.rb
+++ b/spec/turbulence/calculators/churn_spec.rb
@@ -5,150 +5,138 @@ describe Turbulence::Calculators::Churn do
   let(:config) { Turbulence::Configuration.new }
 
   before do
-    calculator.stub(:scm_log_command) { "" }
+    allow(calculator).to receive(:scm_log_command).and_return("")
   end
 
   describe "::for_these_files" do
     it "yields up the filename and score for each file" do
       files = ["lib/corey.rb", "lib/chad.rb"]
-      calculator.stub(:changes_by_ruby_file) {
-        [
-          ["lib/corey.rb", 5],
-          ["lib/chad.rb", 10]
-      ]
-      }
+      allow(calculator).to receive(:changes_by_ruby_file).and_return([
+        ["lib/corey.rb", 5],
+        ["lib/chad.rb", 10]
+      ])
       yielded_files = []
       calculator.for_these_files(files) do |filename, score|
         yielded_files << [filename, score]
       end
-      yielded_files.should =~ [["lib/corey.rb", 5],
-        ["lib/chad.rb",10]]
+      expect(yielded_files).to match_array([["lib/corey.rb", 5], ["lib/chad.rb", 10]])
     end
 
     it "filters the results by the passed-in files" do
       files = ["lib/corey.rb"]
-      calculator.stub(:changes_by_ruby_file) {
-        [
-          ["lib/corey.rb", 5],
-          ["lib/chad.rb", 10]
-      ]
-      }
+      allow(calculator).to receive(:changes_by_ruby_file).and_return([
+        ["lib/corey.rb", 5],
+        ["lib/chad.rb", 10]
+      ])
       yielded_files = []
       calculator.for_these_files(files) do |filename, score|
         yielded_files << [filename, score]
       end
-      yielded_files.should =~ [["lib/corey.rb", 5]]
+      expect(yielded_files).to match_array([["lib/corey.rb", 5]])
     end
   end
 
   describe "::scm_log_file_lines" do
     it "returns just the file lines" do
-      calculator.stub(:scm_log_command) do
-      "\n\n\n\n10\t6\tlib/turbulence.rb\n\n\n\n17\t2\tlib/eddies.rb\n"
-      end
+      allow(calculator).to receive(:scm_log_command).and_return(
+        "\n\n\n\n10\t6\tlib/turbulence.rb\n\n\n\n17\t2\tlib/eddies.rb\n"
+      )
 
-      calculator.scm_log_file_lines.should =~ [
+      expect(calculator.scm_log_file_lines).to match_array([
         "10\t6\tlib/turbulence.rb",
         "17\t2\tlib/eddies.rb"
-      ]
+      ])
     end
   end
 
   describe "::counted_line_changes_by_file_by_commit" do
     before do
-      calculator.stub(:scm_log_file_lines) {
-        [
-          "10\t6\tlib/turbulence.rb",
-          "17\t2\tlib/eddies.rb"
-        ]
-      }
+      allow(calculator).to receive(:scm_log_file_lines).and_return([
+        "10\t6\tlib/turbulence.rb",
+        "17\t2\tlib/eddies.rb"
+      ])
     end
 
     it "sums up the line changes" do
-      calculator.counted_line_changes_by_file_by_commit.should =~ [["lib/turbulence.rb", 16], ["lib/eddies.rb", 19]]
+      expect(calculator.counted_line_changes_by_file_by_commit).to match_array([["lib/turbulence.rb", 16], ["lib/eddies.rb", 19]])
     end
   end
-  
+
   describe "::changes_by_ruby_file" do
     before do
-      calculator.stub(:ruby_files_changed_in_scm) {
-        [
-          ['lib/eddies.rb', 4],
-          ['lib/turbulence.rb', 5],
-          ['lib/turbulence.rb', 16],
-          ['lib/eddies.rb', 2],
-          ['lib/turbulence.rb', 7],
-          ['lib/eddies.rb', 19],
-          ['lib/eddies.rb', 28]
-        ]
-      }
+      allow(calculator).to receive(:ruby_files_changed_in_scm).and_return([
+        ['lib/eddies.rb', 4],
+        ['lib/turbulence.rb', 5],
+        ['lib/turbulence.rb', 16],
+        ['lib/eddies.rb', 2],
+        ['lib/turbulence.rb', 7],
+        ['lib/eddies.rb', 19],
+        ['lib/eddies.rb', 28]
+      ])
     end
-    
+
     it "groups and sums churns, excluding the last" do
       calculator.compute_mean = false
-      calculator.changes_by_ruby_file.should =~ [ ['lib/eddies.rb', 25], ['lib/turbulence.rb', 21]]
+      expect(calculator.changes_by_ruby_file).to match_array([['lib/eddies.rb', 25], ['lib/turbulence.rb', 21]])
     end
 
     it "interprets a single entry as zero churn" do
-      calculator.stub(:ruby_files_changed_in_scm) {
-        [
-          ['lib/eddies.rb', 4],
-        ]
-      }
+      allow(calculator).to receive(:ruby_files_changed_in_scm).and_return([
+        ['lib/eddies.rb', 4],
+      ])
       calculator.compute_mean = false
-      calculator.changes_by_ruby_file.should =~ [ ['lib/eddies.rb', 0] ]
+      expect(calculator.changes_by_ruby_file).to match_array([['lib/eddies.rb', 0]])
     end
-    
+
     it "groups and takes the mean of churns, excluding the last" do
       calculator.compute_mean = true
-      calculator.changes_by_ruby_file.should =~ [ ['lib/eddies.rb', 8], ['lib/turbulence.rb', 10]]
+      expect(calculator.changes_by_ruby_file).to match_array([['lib/eddies.rb', 8], ['lib/turbulence.rb', 10]])
       calculator.compute_mean = false
     end
   end
 
   describe "::calculate_mean_of_churn" do
     it "handles zero sample size" do
-      calculator.calculate_mean_of_churn(8,0).should == 8
+      expect(calculator.calculate_mean_of_churn(8, 0)).to eq 8
     end
 
-    it "returns original churn for sample size = 1"  do
-      calculator.calculate_mean_of_churn(8,1).should == 8
+    it "returns original churn for sample size = 1" do
+      expect(calculator.calculate_mean_of_churn(8, 1)).to eq 8
     end
 
     it "returns churn divided by sample size" do
-      calculator.calculate_mean_of_churn(25,3).should == 8
+      expect(calculator.calculate_mean_of_churn(25, 3)).to eq 8
     end
-
   end
 
   context "Full stack tests" do
     context "when one ruby file is given" do
       context "with two log entries for file" do
         before do
-          calculator.stub(:scm_log_command) do
+          allow(calculator).to receive(:scm_log_command).and_return(
             "\n\n\n\n10\t6\tlib/turbulence.rb\n" +
-              "\n\n\n\n11\t7\tlib/turbulence.rb\n"
-          end
+            "\n\n\n\n11\t7\tlib/turbulence.rb\n"
+          )
         end
         it "gives the line change count for the file" do
           yielded_files = []
           calculator.for_these_files(["lib/turbulence.rb"]) do |filename, score|
             yielded_files << [filename, score]
           end
-          yielded_files.should =~ [["lib/turbulence.rb", 16]]
+          expect(yielded_files).to match_array([["lib/turbulence.rb", 16]])
         end
         context "with only one log entry for file" do
           before do
-            calculator.stub(:scm_log_command) do
+            allow(calculator).to receive(:scm_log_command).and_return(
               "\n\n\n\n10\t6\tlib/turbulence.rb\n"
-            end
+            )
           end
           it "shows zero churn for the file" do
             yielded_files = []
             calculator.for_these_files(["lib/turbulence.rb"]) do |filename, score|
               yielded_files << [filename, score]
             end
-            yielded_files.should =~ [["lib/turbulence.rb", 0]]
+            expect(yielded_files).to match_array([["lib/turbulence.rb", 0]])
           end
         end
       end

--- a/spec/turbulence/calculators/complexity_spec.rb
+++ b/spec/turbulence/calculators/complexity_spec.rb
@@ -7,15 +7,12 @@ describe Turbulence::Calculators::Complexity do
   describe "::for_these_files" do
     it "yields up the filename and score for each file" do
       files = ["lib/corey.rb", "lib/chad.rb"]
-      calculator.stub(:score_for_file) { |filename|
-        filename.size
-      }
+      allow(calculator).to receive(:score_for_file) { |filename| filename.size }
       yielded_files = []
       calculator.for_these_files(files) do |filename, score|
         yielded_files << [filename, score]
       end
-      yielded_files.should =~ [["lib/corey.rb", 12],
-        ["lib/chad.rb",11]]
+      expect(yielded_files).to match_array([["lib/corey.rb", 12], ["lib/chad.rb", 11]])
     end
   end
 end

--- a/spec/turbulence/cli_parser_spec.rb
+++ b/spec/turbulence/cli_parser_spec.rb
@@ -10,31 +10,31 @@ describe Turbulence::CommandLineInterface::ConfigParser do
 
   it "sets directory" do
     parse %w( path/to/compute )
-    config.directory.should == 'path/to/compute'
+    expect(config.directory).to eq 'path/to/compute'
   end
 
   it "sets SCM name to 'Perforce'" do
     parse %w( --scm p4 )
-    config.scm_name.should == 'Perforce'
+    expect(config.scm_name).to eq 'Perforce'
   end
 
   it "sets commit range" do
     parse %w( --churn-range f3e1d7a6..830b9d3d9f )
-    config.commit_range.should eq('f3e1d7a6..830b9d3d9f')
+    expect(config.commit_range).to eq 'f3e1d7a6..830b9d3d9f'
   end
 
   it "sets compute mean" do
     parse %w( --churn-mean )
-    config.compute_mean.should be_true
+    expect(config.compute_mean).to be true
   end
 
   it "sets the exclusion pattern" do
     parse %w( --exclude turbulence )
-    config.exclusion_pattern.should == 'turbulence'
+    expect(config.exclusion_pattern).to eq 'turbulence'
   end
 
   it "sets the graph type" do
     parse %w( --treemap )
-    config.graph_type.should == 'treemap'
+    expect(config.graph_type).to eq 'treemap'
   end
 end

--- a/spec/turbulence/command_line_interface_spec.rb
+++ b/spec/turbulence/command_line_interface_spec.rb
@@ -6,7 +6,9 @@ describe Turbulence::CommandLineInterface do
 
   describe "::TEMPLATE_FILES" do
     Turbulence::CommandLineInterface::TEMPLATE_FILES.each do |template_file|
-      File.dirname(template_file).should == Turbulence::CommandLineInterface::TURBULENCE_TEMPLATE_PATH
+      it "has #{File.basename(template_file)} in the template path" do
+        expect(File.dirname(template_file)).to eq Turbulence::CommandLineInterface::TURBULENCE_TEMPLATE_PATH
+      end
     end
   end
 
@@ -16,18 +18,18 @@ describe Turbulence::CommandLineInterface do
     end
     it "bundles the files" do
       cli.generate_bundle
-      Dir.glob('turbulence/*').sort.should eq(["turbulence/cc.js",
-                                               "turbulence/highcharts.js",
-                                               "turbulence/jquery.min.js",
-                                               "turbulence/treemap.html",
-                                               "turbulence/turbulence.html"])
+      expect(Dir.glob('turbulence/*').sort).to eq(["turbulence/cc.js",
+                                                   "turbulence/highcharts.js",
+                                                   "turbulence/jquery.min.js",
+                                                   "turbulence/treemap.html",
+                                                   "turbulence/turbulence.html"])
     end
 
     it "passes along exclusion pattern" do
       cli = Turbulence::CommandLineInterface.new(%w(--exclude turbulence), :output => nil)
       cli.generate_bundle
       lines = File.new('turbulence/cc.js').readlines
-      lines.any? { |l| l =~ /turbulence\.rb/ }.should be_false
+      expect(lines.any? { |l| l =~ /turbulence\.rb/ }).to be false
     end
   end
 end

--- a/spec/turbulence/configuration_spec.rb
+++ b/spec/turbulence/configuration_spec.rb
@@ -1,4 +1,5 @@
 require 'rspec'
+require 'rspec/its'
 require 'turbulence'
 
 describe Turbulence::Configuration do

--- a/spec/turbulence/generators/scatter_plot_spec.rb
+++ b/spec/turbulence/generators/scatter_plot_spec.rb
@@ -2,16 +2,16 @@ require 'turbulence'
 
 describe Turbulence::Generators::ScatterPlot do
   context "with both Metrics" do
-    it "generates JavaScript" do
+    it "generates JavaScript", :aggregate_failures do
       generator = Turbulence::Generators::ScatterPlot.new(
         "foo.rb" => { :churn      => 1,
                       :complexity => 2 }
       )
 
-      generator.to_js.should =~ /var directorySeries/
-      generator.to_js.should =~ /\"filename\"\:\"foo.rb\"/
-      generator.to_js.should =~ /\"x\":1/
-      generator.to_js.should =~ /\"y\":2/
+      expect(generator.to_js).to match(/var directorySeries/)
+      expect(generator.to_js).to match(/\"filename\"\:\"foo.rb\"/)
+      expect(generator.to_js).to match(/\"x\":1/)
+      expect(generator.to_js).to match(/\"y\":2/)
     end
   end
 
@@ -21,76 +21,79 @@ describe Turbulence::Generators::ScatterPlot do
         "foo.rb" => { :churn => 1 }
       )
 
-      generator.to_js.should == 'var directorySeries = {};'
+      expect(generator.to_js).to eq 'var directorySeries = {};'
     end
   end
 
   describe "#clean_metrics_from_missing_data" do
-    let(:spg) {Turbulence::Generators::ScatterPlot.new({})}
+    let(:spg) { Turbulence::Generators::ScatterPlot.new({}) }
 
     it "removes entries with missing churn" do
-      spg.stub(:metrics_hash).and_return("foo.rb" => {
-        :complexity => 88.3})
-        spg.clean_metrics_from_missing_data.should == {}
+      allow(spg).to receive(:metrics_hash).and_return("foo.rb" => { :complexity => 88.3 })
+      expect(spg.clean_metrics_from_missing_data).to eq({})
     end
 
     it "removes entries with missing complexity" do
-      spg.stub(:metrics_hash).and_return("foo.rb" => {
-        :churn => 1})
-        spg.clean_metrics_from_missing_data.should == {}
+      allow(spg).to receive(:metrics_hash).and_return("foo.rb" => { :churn => 1 })
+      expect(spg.clean_metrics_from_missing_data).to eq({})
     end
 
     it "keeps entries with churn and complexity present" do
-      spg.stub(:metrics_hash).and_return("foo.rb" => {
+      allow(spg).to receive(:metrics_hash).and_return("foo.rb" => {
         :churn      => 1,
         :complexity => 88.3,
-        })
+      })
 
-        spg.clean_metrics_from_missing_data.should_not == {}
+      expect(spg.clean_metrics_from_missing_data).not_to eq({})
     end
   end
 
   describe "#grouped_by_directory" do
-    let(:spg) {Turbulence::Generators::ScatterPlot.new("lib/foo/foo.rb" => {
-      :churn => 1},
-      "lib/bar.rb" => {
-      :churn => 2} )}
+    let(:spg) {
+      Turbulence::Generators::ScatterPlot.new(
+        "lib/foo/foo.rb" => { :churn => 1 },
+        "lib/bar.rb" => { :churn => 2 }
+      )
+    }
 
-      it "uses \".\" to denote flat hierarchy" do
-        spg.stub(:metrics_hash).and_return("foo.rb" => {
-          :churn => 1
-        })
-        spg.grouped_by_directory.should == {"." => [["foo.rb", {:churn => 1}]]}
-      end
+    it "uses \".\" to denote flat hierarchy" do
+      allow(spg).to receive(:metrics_hash).and_return("foo.rb" => { :churn => 1 })
+      expect(spg.grouped_by_directory).to eq({ "." => [["foo.rb", { :churn => 1 }]] })
+    end
 
-      it "takes full path into account" do
-        spg.grouped_by_directory.should == {"lib/foo" => [["lib/foo/foo.rb", {:churn => 1}]],
-          "lib" => [["lib/bar.rb", {:churn => 2}]]}
-      end
+    it "takes full path into account" do
+      expect(spg.grouped_by_directory).to eq({
+        "lib/foo" => [["lib/foo/foo.rb", { :churn => 1 }]],
+        "lib" => [["lib/bar.rb", { :churn => 2 }]]
+      })
+    end
   end
 
   describe "#file_metrics_for_directory" do
-    let(:spg) {Turbulence::Generators::ScatterPlot.new({})}
+    let(:spg) { Turbulence::Generators::ScatterPlot.new({}) }
+
     it "assigns :filename, :x, :y" do
-      spg.file_metrics_for_directory("lib/foo/foo.rb" => {
+      result = spg.file_metrics_for_directory("lib/foo/foo.rb" => {
         :churn      => 1,
         :complexity => 88.2,
-      }).should == [{:filename => "lib/foo/foo.rb", :x => 1, :y => 88.2}]
+      })
+      expect(result).to eq [{ :filename => "lib/foo/foo.rb", :x => 1, :y => 88.2 }]
     end
   end
 
   describe Turbulence::FileNameMangler do
     subject { Turbulence::FileNameMangler.new }
+
     it "anonymizes a string" do
-      subject.mangle_name("chad").should_not == "chad"
+      expect(subject.mangle_name("chad")).not_to eq "chad"
     end
 
     it "maintains standard directory names" do
-      subject.mangle_name("/app/controllers/chad.rb").should =~ %r{/app/controllers/1.rb}
+      expect(subject.mangle_name("/app/controllers/chad.rb")).to match(%r{/app/controllers/1.rb})
     end
 
     it "honors leading path separators" do
-      subject.mangle_name("/a/b/c.rb").should == "/1/2/3.rb"
+      expect(subject.mangle_name("/a/b/c.rb")).to eq "/1/2/3.rb"
     end
   end
 end

--- a/spec/turbulence/generators/treemap_spec.rb
+++ b/spec/turbulence/generators/treemap_spec.rb
@@ -2,14 +2,14 @@ require 'turbulence'
 
 describe Turbulence::Generators::TreeMap do
   context "with both Metrics" do
-    it "generates JavaScript" do
+    it "generates JavaScript", :aggregate_failures do
       generator = Turbulence::Generators::TreeMap.new(
         "foo.rb" => { :churn      => 1,
                       :complexity => 2 }
       )
 
-      generator.build_js.should =~ /var treemap_data/
-      generator.build_js.should =~ /\'foo.rb\'/
+      expect(generator.build_js).to match(/var treemap_data/)
+      expect(generator.build_js).to match(/\'foo.rb\'/)
     end
   end
 
@@ -19,7 +19,7 @@ describe Turbulence::Generators::TreeMap do
         "foo.rb" => { :churn => 1 }
       )
 
-      generator.build_js.should == "var treemap_data = [['File', 'Parent', 'Churn (size)', 'Complexity (color)'],\n['Root', null, 0, 0],\n];"
+      expect(generator.build_js).to eq "var treemap_data = [['File', 'Parent', 'Churn (size)', 'Complexity (color)'],\n['Root', null, 0, 0],\n];"
     end
   end
 end

--- a/spec/turbulence/scm/git_spec.rb
+++ b/spec/turbulence/scm/git_spec.rb
@@ -5,25 +5,26 @@ require 'fileutils'
 describe Turbulence::Scm::Git do
   describe "::is_repo?" do
     before do
-      @tmp = Dir.mktmpdir(nil,'..')
+      # Create temp dir in system temp location (outside any git repo)
+      @tmp = Dir.mktmpdir('turbulence-test')
     end
     after do
-      FileUtils.rmdir(@tmp)
+      FileUtils.remove_entry(@tmp)
     end
     it "returns true for the working directory" do
-      Turbulence::Scm::Git.is_repo?(".").should == true
+      expect(Turbulence::Scm::Git.is_repo?(".")).to eq true
     end
     it "return false for a newly created tmp directory" do
-      Turbulence::Scm::Git.is_repo?(@tmp).should == false
+      expect(Turbulence::Scm::Git.is_repo?(@tmp)).to eq false
     end
   end
 
   describe "::log_command" do
     it "takes an optional argument specify to the range" do
-      expect{Turbulence::Scm::Git.log_command("d551e63f79a90430e560ea871f4e1e39e6e739bd  HEAD")}.to_not raise_error
+      expect { Turbulence::Scm::Git.log_command("d551e63f79a90430e560ea871f4e1e39e6e739bd  HEAD") }.to_not raise_error
     end
     it "lists insertions/deletions per file and change" do
-      Turbulence::Scm::Git.log_command.should match(/\d+\t\d+\t[A-z.]*/)
+      expect(Turbulence::Scm::Git.log_command).to match(/\d+\t\d+\t[A-z.]*/)
     end
   end
 end

--- a/spec/turbulence/scm/perforce_spec.rb
+++ b/spec/turbulence/scm/perforce_spec.rb
@@ -1,11 +1,10 @@
 require 'turbulence/scm/perforce'
-require 'rspec/mocks'
 
 describe Turbulence::Scm::Perforce do
-  let (:p4_scm) { Turbulence::Scm::Perforce }
+  let(:p4_scm) { Turbulence::Scm::Perforce }
 
   before do
-    p4_scm.stub(:p4_list_changes) do
+    allow(p4_scm).to receive(:p4_list_changes).and_return(
       "Change 62660 on 2005/11/28 by x@client 'CHANGED: adapted to DESCODE '
 Change 45616 on 2005/07/12 by x@client 'ADDED: trigger that builds and '
 Change 45615 on 2005/07/12 by x@client 'ADDED: for testing purposes '
@@ -13,9 +12,9 @@ Change 45614 on 2005/07/12 by x@client 'COSMETIC: updated header '
 Change 11250 on 2004/09/17 by x@client 'CHANGED: trigger now also allow'
 Change 9250 on 2004/08/20 by x@client 'BUGFIX: bug#1583 (People can so'
 Change 5560 on 2004/04/26 by x@client 'ADDED: The \"BRANCHED\" tag.'"
-    end
+    )
 
-    p4_scm.stub(:p4_describe_change).with("5560") do
+    allow(p4_scm).to receive(:p4_describe_change).with("5560").and_return(
       "Change 5560 by x@client on 2004/04/26 17:25:03
 
         ADDED: The \"BRANCHED\" tag.
@@ -38,105 +37,111 @@ changed 1 chunks 3 / 3 lines
 add 0 chunks 0 lines
 deleted 0 chunks 0 lines
 changed 1 chunks 3 / 1 lines"
-    end
+    )
   end
 
   describe "::is_repo?" do
     before :each do
-      ENV.stub(:[]).with("P4CLIENT").and_return(nil)
-      ENV.stub(:[]).with("PATH").and_return("")
+      allow(ENV).to receive(:[]).with("P4CLIENT").and_return(nil)
+      allow(ENV).to receive(:[]).with("PATH").and_return("")
     end
 
     it "returns true if P4CLIENT is set " do
-      ENV.stub(:[]).with("P4CLIENT").and_return("c-foo.bar")
+      allow(ENV).to receive(:[]).with("P4CLIENT").and_return("c-foo.bar")
 
-      Turbulence::Scm::Perforce.is_repo?(".").should be_true
+      expect(Turbulence::Scm::Perforce.is_repo?(".")).to be true
     end
 
-    it "returns false if P4CLIENT is empty"  do
-      Turbulence::Scm::Perforce.is_repo?(".").should be_false
+    it "returns false if P4CLIENT is empty" do
+      expect(Turbulence::Scm::Perforce.is_repo?(".")).to be false
     end
 
     it "returns false if p4 is not available" do
-      Turbulence::Scm::Perforce.is_repo?(".").should be_false
+      expect(Turbulence::Scm::Perforce.is_repo?(".")).to be false
     end
   end
 
   describe "::log_command" do
     before do
-      p4_scm.stub(:depot_to_local).with("//admin/scripts/triggers/enforce-submit-comment.py")\
+      allow(p4_scm).to receive(:depot_to_local)
+        .with("//admin/scripts/triggers/enforce-submit-comment.py")
         .and_return("triggers/enforce-submit-comments.py")
-      p4_scm.stub(:depot_to_local).with("//admin/scripts/triggers/check-consistency.py")\
+      allow(p4_scm).to receive(:depot_to_local)
+        .with("//admin/scripts/triggers/check-consistency.py")
         .and_return("triggers/check-consistency.py")
-      p4_scm.stub(:p4_list_changes) do
+      allow(p4_scm).to receive(:p4_list_changes).and_return(
         "Change 5560 on 2004/04/26 by x@client 'ADDED: The \"BRANCHED\" tag.'"
-      end
+      )
     end
 
     it "takes an optional argument to specify the range" do
-      expect{Turbulence::Scm::Perforce.log_command("@1,2")}.to_not raise_error
+      expect { Turbulence::Scm::Perforce.log_command("@1,2") }.to_not raise_error
     end
 
     it "lists insertions/deletions per file and change" do
-      Turbulence::Scm::Perforce.log_command().should match(/\d+\t\d+\t[A-z.]*/)
+      expect(Turbulence::Scm::Perforce.log_command()).to match(/\d+\t\d+\t[A-z.]*/)
     end
   end
 
   describe "::changes" do
     it "lists changenumbers from parsing 'p4 changes' output" do
-      p4_scm.changes.should =~ %w[62660 45616 45615 45614 11250 9250 5560]
+      expect(p4_scm.changes).to match_array(%w[62660 45616 45615 45614 11250 9250 5560])
     end
   end
 
   describe "::files_per_change" do
     before do
-      p4_scm.stub(:depot_to_local).with("//admin/scripts/triggers/enforce-submit-comment.py")\
+      allow(p4_scm).to receive(:depot_to_local)
+        .with("//admin/scripts/triggers/enforce-submit-comment.py")
         .and_return("triggers/enforce-submit-comments.py")
-      p4_scm.stub(:depot_to_local).with("//admin/scripts/triggers/check-consistency.py")\
+      allow(p4_scm).to receive(:depot_to_local)
+        .with("//admin/scripts/triggers/check-consistency.py")
         .and_return("triggers/check-consistency.py")
     end
 
     it "lists files with churn" do
-      p4_scm.files_per_change("5560").should  =~ [[4,"triggers/enforce-submit-comments.py"],
-        [1,"triggers/check-consistency.py"]]
+      expect(p4_scm.files_per_change("5560")).to match_array([
+        [4, "triggers/enforce-submit-comments.py"],
+        [1, "triggers/check-consistency.py"]
+      ])
     end
   end
 
   describe "::transform_for_output" do
     it "adds a 0 for deletions" do
-      p4_scm.transform_for_output([1,"triggers/check-consistency.py"]).should == "1\t0\ttriggers/check-consistency.py\n"
+      expect(p4_scm.transform_for_output([1, "triggers/check-consistency.py"])).to eq "1\t0\ttriggers/check-consistency.py\n"
     end
   end
 
   describe "::depot_to_local" do
     describe "on windows" do
       before do
-        p4_scm.stub(:extract_clientfile_from_fstat_of).and_return("D:/Perforce/admin/scripts/triggers/enforce-no-head-change.py")
-        FileUtils.stub(:pwd).and_return("D:/Perforce")
+        allow(p4_scm).to receive(:extract_clientfile_from_fstat_of)
+          .and_return("D:/Perforce/admin/scripts/triggers/enforce-no-head-change.py")
+        allow(FileUtils).to receive(:pwd).and_return("D:/Perforce")
       end
 
       it "converts depot-style paths to local paths using forward slashes" do
-        p4_scm.depot_to_local("//admin/scripts/triggers/enforce-no-head-change.py").should \
-          == "admin/scripts/triggers/enforce-no-head-change.py"
+        expect(p4_scm.depot_to_local("//admin/scripts/triggers/enforce-no-head-change.py")).to eq "admin/scripts/triggers/enforce-no-head-change.py"
       end
     end
 
     describe "on unix" do
       before do
-        p4_scm.stub(:extract_clientfile_from_fstat_of).and_return("/home/jhwist/admin/scripts/triggers/enforce-no-head-change.py")
-        FileUtils.stub(:pwd).and_return("/home/jhwist")
+        allow(p4_scm).to receive(:extract_clientfile_from_fstat_of)
+          .and_return("/home/jhwist/admin/scripts/triggers/enforce-no-head-change.py")
+        allow(FileUtils).to receive(:pwd).and_return("/home/jhwist")
       end
 
       it "converts depot-style paths to local paths using forward slashes" do
-        p4_scm.depot_to_local("//admin/scripts/triggers/enforce-no-head-change.py").should \
-          == "admin/scripts/triggers/enforce-no-head-change.py"
+        expect(p4_scm.depot_to_local("//admin/scripts/triggers/enforce-no-head-change.py")).to eq "admin/scripts/triggers/enforce-no-head-change.py"
       end
     end
   end
 
   describe "::extract_clientfile_from_fstat_of" do
     before do
-      p4_scm.stub(:p4_fstat) do
+      allow(p4_scm).to receive(:p4_fstat).and_return(
         "... depotFile //admin/scripts/triggers/enforce-no-head-change.py
 ... clientFile /home/jhwist/admin/scripts/triggers/enforce-no-head-change.py
 ... isMapped
@@ -147,24 +152,23 @@ changed 1 chunks 3 / 1 lines"
 ... headChange 211211
 ... headModTime 1214555028
 ... haveRev 5"
-      end
+      )
     end
 
-    it "uses clientFile field"  do
-      p4_scm.extract_clientfile_from_fstat_of("//admin/scripts/triggers/enforce-no-head-change.py").should ==
-        "/home/jhwist/admin/scripts/triggers/enforce-no-head-change.py"
+    it "uses clientFile field" do
+      expect(p4_scm.extract_clientfile_from_fstat_of("//admin/scripts/triggers/enforce-no-head-change.py")).to eq "/home/jhwist/admin/scripts/triggers/enforce-no-head-change.py"
     end
   end
 
   describe "::sum_of_changes" do
     it "sums up changes" do
       output = "add 1 chunks 1 lines\ndeleted 0 chunks 0 lines\nchanged 1 chunks 3 / 3 lines"
-      p4_scm.sum_of_changes(output).should == 4
+      expect(p4_scm.sum_of_changes(output)).to eq 4
     end
 
     it "ignores junk" do
       output = "add nothing, change nothing"
-      p4_scm.sum_of_changes(output).should == 0
+      expect(p4_scm.sum_of_changes(output)).to eq 0
     end
   end
 end

--- a/spec/turbulence/turbulence_spec.rb
+++ b/spec/turbulence/turbulence_spec.rb
@@ -13,11 +13,11 @@ describe Turbulence do
   }
 
   it "finds files of interest" do
-    turb.files_of_interest.should include "lib/turbulence.rb"
+    expect(turb.files_of_interest).to include "lib/turbulence.rb"
   end
-  
-  it "filters out exluded files" do
+
+  it "filters out excluded files" do
     config.exclusion_pattern = 'turbulence'
-    turb.files_of_interest.should_not include "lib/turbulence.rb"
+    expect(turb.files_of_interest).not_to include "lib/turbulence.rb"
   end
 end

--- a/turbulence.gemspec
+++ b/turbulence.gemspec
@@ -1,4 +1,5 @@
-# -*- encoding: utf-8 -*-
+# frozen_string_literal: true
+
 $:.push File.expand_path("../lib", __FILE__)
 require "turbulence/version"
 
@@ -8,11 +9,16 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Chad Fowler", "Michael Feathers", "Corey Haines"]
   s.email       = ["chad@chadfowler.com", "mfeathers@obtiva.com", "coreyhaines@gmail.com"]
-  s.homepage    = "http://chadfowler.com"
-  s.add_dependency "flog", "~>4.1"
-  s.add_dependency "json", ">= 1.4.6"
+  s.homepage    = "https://github.com/chad/turbulence"
+  s.license     = "MIT"
+
+  s.add_dependency "flog", ">= 4.1"
+  s.add_dependency "json"
   s.add_dependency "launchy", ">= 2.0.0"
-  s.add_development_dependency 'rspec', '~> 2.14.0'
+  s.add_dependency "racc"  # Required by flog's ruby_parser, removed from stdlib in Ruby 3.3+
+
+  s.add_development_dependency 'rspec', '~> 3.0'
+  s.add_development_dependency 'rspec-its'
   s.add_development_dependency 'rake'
 
   s.summary     = %q{Automates churn + flog scoring on a git repo for a Ruby project}
@@ -22,5 +28,5 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-  s.required_ruby_version = '>= 1.8.7'
+  s.required_ruby_version = '>= 3.0'
 end


### PR DESCRIPTION
## Summary

This PR updates turbulence to work with modern Ruby versions (3.0+), including the recently released Ruby 4.0.

## Changes

### Gemspec Updates
- Updated `required_ruby_version` from `>= 1.8.7` to `>= 3.0`
- Added `racc` as runtime dependency (removed from stdlib in Ruby 3.3+)
- Updated RSpec from `~> 2.14.0` to `~> 3.0`
- Added `rspec-its` for `its` syntax support
- Added `frozen_string_literal: true`
- Updated homepage URL and added license field

### Code Changes
- **Removed obsolete `Ruby19Parser`/`Flog19` classes** - These were workarounds for Ruby 1.9 hash syntax that are no longer needed. Now uses `Flog` directly.
- **Removed unused `require 'ostruct'`** from configuration.rb
- **Fixed git repo detection** - Changed regex to case-insensitive (`/not a git repository/i`) as Git's error message changed case between versions

### Test Updates
- Updated all specs to RSpec 3 expect syntax (`should` → `expect().to`)
- Updated all specs to RSpec 3 mock syntax (`stub` → `allow().to receive()`)
- Fixed `git_spec.rb` to create temp directory outside any git repo for accurate testing
- Added `:aggregate_failures` to specs with multiple expectations

## Testing

All 62 tests pass:
```
$ bundle exec rspec
..............................................................

Finished in 0.282 seconds (files took 0.18312 seconds to load)
62 examples, 0 failures
```

Gem builds successfully:
```
$ gem build turbulence.gemspec
  Successfully built RubyGem
  Name: turbulence
  Version: 1.2.4
  File: turbulence-1.2.4.gem
```

## Compatibility

- **Minimum Ruby version**: 3.0
- **Tested on**: Ruby 4.0.5
- **Backwards compatible**: Should work with Ruby 3.0, 3.1, 3.2, 3.3, and 4.0