### PR TITLE
Add GitHub Actions CI and README badges

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,48 @@
+name: CI
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        ruby-version:
+          - '3.0'
+          - '3.1'
+          - '3.2'
+          - '3.3'
+          - 'head'
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby ${{ matrix.ruby-version }}
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby-version }}
+          bundler-cache: true
+
+      - name: Run tests
+        run: bundle exec rspec
+
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+
+      - name: Check gemspec
+        run: gem build turbulence.gemspec --strict

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Hopefully-meaningful Metrics
 ============================
 
+[![CI](https://github.com/chad/turbulence/actions/workflows/ci.yml/badge.svg)](https://github.com/chad/turbulence/actions/workflows/ci.yml)
+[![Gem Version](https://badge.fury.io/rb/turbulence.svg)](https://badge.fury.io/rb/turbulence)
+
 Based on Michael Feathers' [recent work](http://www.stickyminds.com/sitewide.asp?Function=edetail&ObjectType=COL&ObjectId=16679&tth=DYN&tt=siteemail&iDyn=2) in project churn and complexity.
 
 Here is how to read the graph (extracted from the above article):


### PR DESCRIPTION
## Summary

This PR adds modern CI using GitHub Actions and adds status badges to the README.

## Changes

### GitHub Actions Workflow (`.github/workflows/ci.yml`)

**Test Job:**
- Runs on: `ubuntu-latest`
- Ruby versions: 3.0, 3.1, 3.2, 3.3, and head
- Uses `ruby/setup-ruby@v1` with bundler caching
- Runs `bundle exec rspec`

**Lint Job:**
- Verifies gemspec builds cleanly with `--strict` flag

### README Badges

Added two badges:
- **CI Status**: Shows build status from GitHub Actions
- **Gem Version**: Shows current version on RubyGems.org

### Before
```
Hopefully-meaningful Metrics
============================
```

### After
```
Hopefully-meaningful Metrics
============================

[![CI](https://github.com/chad/turbulence/actions/workflows/ci.yml/badge.svg)](https://github.com/chad/turbulence/actions/workflows/ci.yml)
[![Gem Version](https://badge.fury.io/rb/turbulence.svg)](https://badge.fury.io/rb/turbulence)
```

## Notes

- The existing `.travis.yml` only tested Ruby 1.8.7, 1.9.2, 1.9.3, and old JRuby versions
- This PR doesn't remove `.travis.yml` to avoid breaking anything, but it could be removed in a follow-up
- CI will run on pushes to master and on all PRs

## Dependencies

This PR works best when merged after #50 (Ruby 4 compatibility), as the tests won't pass on modern Ruby without those changes.