### PR TITLE
Fix typo: cummulative → cumulative

### DIFF
--- a/lib/turbulence/cli_parser.rb
+++ b/lib/turbulence/cli_parser.rb
@@ -19,7 +19,7 @@ class Turbulence
             config.commit_range = s
           end
 
-          opts.on('--churn-mean', 'calculate mean churn instead of cummulative') do
+          opts.on('--churn-mean', 'calculate mean churn instead of cumulative') do
             config.compute_mean = true
           end
 


### PR DESCRIPTION
Fixes a typo in the `--churn-mean` CLI help text.

Credit to @kianmeng who originally caught this in #48. Their PR became stale after our recent modernization work, so I'm landing the remaining fix here.

Thanks for keeping our docs turbulence-free! ✈️