### PR TITLE
Add --no-open flag to skip automatic browser launch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `--no-open` flag to skip automatic browser launch, useful for CI/headless environments ([#42])
 - GitHub Actions CI testing Ruby 3.0, 3.1, 3.2, 3.3, and head ([#52])
 - CI status badge and RubyGems version badge in README ([#52])
 - LICENSE.txt file (MIT License)

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Options:
   --churn-mean          Calculate mean churn instead of cumulative
   --exclude PATTERN     Exclude files matching pattern
   --treemap             Output treemap graph instead of scatter plot
+  --no-open             Skip opening the report in a browser
 ```
 
 ### Examples
@@ -76,6 +77,9 @@ bule --scm p4
 
 # Analyze only recent changes
 bule --churn-range HEAD~100..HEAD
+
+# Generate report without opening browser (useful for CI)
+bule --no-open
 
 # Exclude test files
 bule --exclude spec

--- a/bin/bule
+++ b/bin/bule
@@ -11,4 +11,4 @@ unless Turbulence::ChecksEnvironment.scm_repo?(Dir.pwd)
 end
 
 cli.generate_bundle
-cli.open_bundle
+cli.open_bundle unless cli.no_open

--- a/lib/turbulence/cli_parser.rb
+++ b/lib/turbulence/cli_parser.rb
@@ -31,6 +31,9 @@ class Turbulence
             config.graph_type = "treemap"
           end
 
+          opts.on('--no-open', 'skip opening the report in a browser') do
+            config.no_open = true
+          end
 
           opts.on_tail("-h", "--help", "Show this message") do
             puts opts

--- a/lib/turbulence/command_line_interface.rb
+++ b/lib/turbulence/command_line_interface.rb
@@ -31,6 +31,7 @@ class Turbulence
       :directory,
       :graph_type,
       :exclusion_pattern,
+      :no_open,
     ]
 
     def copy_templates_into(directory)

--- a/lib/turbulence/configuration.rb
+++ b/lib/turbulence/configuration.rb
@@ -9,6 +9,7 @@ class Turbulence
       :exclusion_pattern,
       :graph_type,
       :output,
+      :no_open,
     ]
 
     def initialize
@@ -16,6 +17,7 @@ class Turbulence
       @graph_type = 'turbulence'
       @scm_name   = 'Git'
       @output     = STDOUT
+      @no_open    = false
     end
 
     # TODO: drop attr accessor and ivar once it stops getting set via Churn


### PR DESCRIPTION
Adds a `--no-open` option that prevents Launchy from opening the generated report in a browser. This is useful for CI/CD pipelines and headless environments like Jenkins where browser launch fails.

## Usage

```bash
# Generate report without opening browser
bule --no-open
```

## Changes

- Add `no_open` configuration option (defaults to `false`)
- Add `--no-open` CLI flag
- Update README with new option and example
- Update CHANGELOG

Closes #42