### PR TITLE
Add --output option to specify report directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `--output DIR` option to specify custom output directory for reports ([#39])
 - `--no-open` flag to skip automatic browser launch, useful for CI/headless environments ([#42])
 - GitHub Actions CI testing Ruby 3.0, 3.1, 3.2, 3.3, and head ([#52])
 - CI status badge and RubyGems version badge in README ([#52])

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Options:
   --exclude PATTERN     Exclude files matching pattern
   --treemap             Output treemap graph instead of scatter plot
   --no-open             Skip opening the report in a browser
+  --output DIR          Output directory for reports (default: ./turbulence)
 ```
 
 ### Examples
@@ -80,6 +81,9 @@ bule --churn-range HEAD~100..HEAD
 
 # Generate report without opening browser (useful for CI)
 bule --no-open
+
+# Output to a custom directory
+bule --output spec/reports/turbulence
 
 # Exclude test files
 bule --exclude spec

--- a/lib/turbulence/cli_parser.rb
+++ b/lib/turbulence/cli_parser.rb
@@ -35,6 +35,10 @@ class Turbulence
             config.no_open = true
           end
 
+          opts.on('--output DIR', String, 'output directory for reports (default: ./turbulence)') do |dir|
+            config.output_dir = dir
+          end
+
           opts.on_tail("-h", "--help", "Show this message") do
             puts opts
             exit

--- a/lib/turbulence/command_line_interface.rb
+++ b/lib/turbulence/command_line_interface.rb
@@ -32,16 +32,21 @@ class Turbulence
       :graph_type,
       :exclusion_pattern,
       :no_open,
+      :output_dir,
     ]
+
+    def output_path
+      output_dir || File.join(Dir.pwd, "turbulence")
+    end
 
     def copy_templates_into(directory)
       FileUtils.cp TEMPLATE_FILES, directory
     end
 
     def generate_bundle
-      FileUtils.mkdir_p("turbulence")
+      FileUtils.mkdir_p(output_path)
 
-      Dir.chdir("turbulence") do
+      Dir.chdir(output_path) do
         turb = Turbulence.new(config)
 
         generator = case graph_type
@@ -56,7 +61,7 @@ class Turbulence
     end
 
     def open_bundle
-      Launchy.open("file:///#{directory}/turbulence/#{graph_type}.html")
+      Launchy.open("file:///#{output_path}/#{graph_type}.html")
     end
   end
 end

--- a/lib/turbulence/configuration.rb
+++ b/lib/turbulence/configuration.rb
@@ -9,6 +9,7 @@ class Turbulence
       :exclusion_pattern,
       :graph_type,
       :output,
+      :output_dir,
       :no_open,
     ]
 
@@ -17,6 +18,7 @@ class Turbulence
       @graph_type = 'turbulence'
       @scm_name   = 'Git'
       @output     = STDOUT
+      @output_dir = nil
       @no_open    = false
     end
 


### PR DESCRIPTION
Adds an `--output` option to specify where the generated reports should be written. This allows users to output reports to custom locations like `spec/reports/turbulence` instead of the default `./turbulence` directory.

## Usage

```bash
# Output to a custom directory
bule --output spec/reports/turbulence

# Combine with other options for CI
bule --output spec/reports/turbulence --no-open
```

## Changes

- Add `output_dir` configuration option
- Add `--output DIR` CLI flag
- Add `output_path` helper method that defaults to `./turbulence`
- Update README with new option and example
- Update CHANGELOG

Closes #39