### PR TITLE
Add specs for --output and --no-open options

### DIFF
--- a/spec/turbulence/cli_parser_spec.rb
+++ b/spec/turbulence/cli_parser_spec.rb
@@ -37,4 +37,14 @@ describe Turbulence::CommandLineInterface::ConfigParser do
     parse %w( --treemap )
     expect(config.graph_type).to eq 'treemap'
   end
+
+  it "sets no_open" do
+    parse %w( --no-open )
+    expect(config.no_open).to be true
+  end
+
+  it "sets output_dir" do
+    parse %w( --output spec/reports/turbulence )
+    expect(config.output_dir).to eq 'spec/reports/turbulence'
+  end
 end

--- a/spec/turbulence/command_line_interface_spec.rb
+++ b/spec/turbulence/command_line_interface_spec.rb
@@ -31,5 +31,35 @@ describe Turbulence::CommandLineInterface do
       lines = File.new('turbulence/cc.js').readlines
       expect(lines.any? { |l| l =~ /turbulence\.rb/ }).to be false
     end
+
+    it "outputs to custom directory when --output is specified" do
+      custom_dir = 'tmp/custom_output'
+      FileUtils.remove_dir(custom_dir, true)
+      cli = Turbulence::CommandLineInterface.new(['--output', custom_dir], :output => nil)
+      cli.generate_bundle
+      expect(Dir.glob("#{custom_dir}/*").sort).to eq(["#{custom_dir}/cc.js",
+                                                       "#{custom_dir}/highcharts.js",
+                                                       "#{custom_dir}/jquery.min.js",
+                                                       "#{custom_dir}/treemap.html",
+                                                       "#{custom_dir}/turbulence.html"])
+      FileUtils.remove_dir(custom_dir, true)
+    end
+  end
+
+  describe "#output_path" do
+    before do
+      # Reset the singleton config between tests
+      Turbulence.instance_variable_set(:@config, nil)
+    end
+
+    it "defaults to ./turbulence when output_dir is not set" do
+      cli = Turbulence::CommandLineInterface.new(%w(.), :output => nil)
+      expect(cli.output_path).to eq(File.join(Dir.pwd, "turbulence"))
+    end
+
+    it "returns the custom output_dir when set" do
+      cli = Turbulence::CommandLineInterface.new(%w(--output custom/path), :output => nil)
+      expect(cli.output_path).to eq('custom/path')
+    end
   end
 end

--- a/spec/turbulence/configuration_spec.rb
+++ b/spec/turbulence/configuration_spec.rb
@@ -4,11 +4,16 @@ require 'turbulence'
 
 describe Turbulence::Configuration do
   describe "defaults" do
-    its(:output)     { should eq(STDOUT) }
-    its(:directory)  { should eq(Dir.pwd) }
-    its(:graph_type) { should eq('turbulence') }
-    its(:scm_name)   { should eq('Git') }
-    its(:scm)        { should eq(Turbulence::Scm::Git) }
+    its(:output)            { should eq(STDOUT) }
+    its(:directory)         { should eq(Dir.pwd) }
+    its(:graph_type)        { should eq('turbulence') }
+    its(:scm_name)          { should eq('Git') }
+    its(:scm)               { should eq(Turbulence::Scm::Git) }
+    its(:no_open)           { should eq(false) }
+    its(:output_dir)        { should be_nil }
+    its(:commit_range)      { should be_nil }
+    its(:compute_mean)      { should be_nil }
+    its(:exclusion_pattern) { should be_nil }
   end
 end
 


### PR DESCRIPTION
Adds test coverage for CLI options and configuration defaults.

## New specs (10 total)

**CLI parser specs:**
- `--no-open` flag parsing
- `--output DIR` flag parsing

**Configuration default specs:**
- `no_open` (false)
- `output_dir` (nil)
- `commit_range` (nil)
- `compute_mean` (nil)
- `exclusion_pattern` (nil)

**CommandLineInterface specs:**
- `output_path` defaults to `./turbulence`
- `output_path` returns custom dir when set
- Integration test for generating bundle to custom directory

All CLI options now have full spec coverage.