### PR TITLE
Add legend and usage tips to treemap view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Legend and usage tips to treemap view explaining size=churn, color=complexity ([#64])
+
 ## [1.3.0] - 2026-06-13
 
 ### Added
@@ -182,6 +185,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [0.0.3]: https://github.com/chad/turbulence/compare/0.0.2...0.0.3
 [0.0.2]: https://github.com/chad/turbulence/releases/tag/0.0.2
 
+[#64]: https://github.com/chad/turbulence/pull/64
 [#58]: https://github.com/chad/turbulence/pull/58
 [#56]: https://github.com/chad/turbulence/pull/56
 [#54]: https://github.com/chad/turbulence/pull/54

--- a/template/treemap.html
+++ b/template/treemap.html
@@ -21,9 +21,69 @@
           showTooltips: true});
         }
     </script>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        margin: 20px;
+      }
+      h1 {
+        font-size: 1.5em;
+        margin-bottom: 0.5em;
+      }
+      .legend {
+        display: flex;
+        gap: 30px;
+        margin-bottom: 15px;
+        font-size: 14px;
+      }
+      .legend-item {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+      }
+      .legend-icon {
+        width: 20px;
+        height: 20px;
+        border: 1px solid #ccc;
+      }
+      .legend-icon.size-large { width: 24px; height: 24px; background: #888; }
+      .legend-icon.size-small { width: 12px; height: 12px; background: #888; }
+      .color-gradient {
+        width: 80px;
+        height: 20px;
+        background: linear-gradient(to right, #0d0, #ddd, #f00);
+      }
+      .tip {
+        margin-top: 15px;
+        padding: 10px 15px;
+        background: #fffbe6;
+        border-left: 4px solid #f90;
+        font-size: 13px;
+        max-width: 900px;
+      }
+    </style>
   </head>
 
   <body>
+    <h1>Churn vs Complexity Treemap</h1>
+    <div class="legend">
+      <div class="legend-item">
+        <strong>Size</strong> = Churn (how often the file changes)
+        <span class="legend-icon size-large"></span>
+        <span style="font-size: 12px;">more</span>
+        <span class="legend-icon size-small"></span>
+        <span style="font-size: 12px;">less</span>
+      </div>
+      <div class="legend-item">
+        <strong>Color</strong> = Complexity
+        <div class="color-gradient"></div>
+        <span style="font-size: 12px;">low → high</span>
+      </div>
+    </div>
     <div id="chart_div" style="width: 900px; height: 500px;"></div>
+    <div class="tip">
+      <strong>Tip:</strong> Look for <strong>big red boxes</strong> — these are high-churn, high-complexity files and prime candidates for refactoring.
+      Click to zoom in, right-click to zoom out.
+    </div>
   </body>
 </html>


### PR DESCRIPTION
## Summary

The treemap visualization now includes a legend and usage tips to help users understand what they're looking at.

### Changes

- **Title** — "Churn vs Complexity Treemap" header
- **Legend** explaining:
  - **Size** = Churn (how often the file changes)
  - **Color** = Complexity (green → red gradient)
- **Tip box** — "Look for big red boxes" + navigation hints (click to zoom, right-click to zoom out)
- **Styling** — Clean system fonts and spacing

### Before / After

| Before | After |
|--------|-------|
| <img width="1798" height="1006" alt="image" src="https://github.com/user-attachments/assets/cb85e373-097f-4fd3-a74e-1eab74ac2779" /> | <img width="1952" height="1458" alt="image" src="https://github.com/user-attachments/assets/9ab63542-05b0-4586-916d-cfcefd130b10" /> |

### Why

Addresses feedback in #63 — users found the treemap difficult to interpret without knowing what size and color represent.

Closes #63